### PR TITLE
Add an external link icon for Slack link

### DIFF
--- a/app/views/application/_menu.html.slim
+++ b/app/views/application/_menu.html.slim
@@ -2,4 +2,7 @@
 = active_link_to t("pages.users"), users_path, wrap_tag: :li
 = active_link_to t("pages.photos"), photos_path, wrap_tag: :li
 = active_link_to t("pages.about.link"), about_path, wrap_tag: :li
-li = link_to t("pages.slack"), Settings.community.link_to.slack, target: "_blank"
+li = link_to Settings.community.link_to.slack, target: "_blank" do
+     i.fa.fa-external-link
+     | &nbsp;
+     = t("pages.slack")


### PR DESCRIPTION
So more clearly that the link leads to an external resource (see screenshot)

![joxi_screenshot_1483373517204](https://cloud.githubusercontent.com/assets/4408379/21592543/5d5b36b0-d11f-11e6-80c4-cece890d5aee.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/it61/it61-rails/99)
<!-- Reviewable:end -->
